### PR TITLE
[feat] #h2-console 옵션 삭제

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,9 @@ spring:
     username: shin
     password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
+#    url: jdbc:h2:mem:testdb
+#    username: sa
+#    driver-class-name: org.h2.Driver
   jpa:
     open-in-view: false
     defer-datasource-initialization: true
@@ -24,15 +27,4 @@ spring:
       hibernate.default_batch_fetch_size: 100
       h2.console.enabled: false
   sql.init.mode: always
-  data.rest:
-    base-path: /api
-    detection-strategy: annotated
 
----
-spring:
-  config.activate.on-profile: testdb
-  datasource:
-    url: jdbc:h2:mem:board;mode=mysql
-    driver-class-name: org.h2.Driver
-  sql.init.mode: always
-#  test.database.replace: none


### PR DESCRIPTION
h2 는 따로 사용하지 않을 거기 때문에 콘솔도 필요없다. 데모가 끝났으므로 삭제